### PR TITLE
A less ugly approach to another source base

### DIFF
--- a/openjdk-docker/OpenJDK9/Dockerfile
+++ b/openjdk-docker/OpenJDK9/Dockerfile
@@ -1,4 +1,4 @@
-FROM base-image/openjdk:latest 
+FROM neomatrix369/openjdk-base-image:latest 
 
 MAINTAINER @adoptopenjdk
   

--- a/openjdk-docker/OpenJDK9/Dockerfile
+++ b/openjdk-docker/OpenJDK9/Dockerfile
@@ -1,4 +1,4 @@
-FROM base-image/openjdk:latest
+FROM base-image/openjdk:latest 
 
 MAINTAINER @adoptopenjdk
   

--- a/openjdk-docker/OpenJDK9/Dockerfile.valhalla
+++ b/openjdk-docker/OpenJDK9/Dockerfile.valhalla
@@ -1,0 +1,37 @@
+FROM base-image/openjdk:latest 
+
+MAINTAINER @adoptopenjdk
+  
+RUN \
+  cd /tmp && \
+  hg clone http://hg.openjdk.java.net/valhalla/valhalla openjdk9 && \ 
+  cd openjdk9 && \
+  sh ./get_source.sh 
+
+RUN \
+  apt-get install -y wget && \
+  wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.tar.gz
+
+RUN \
+  tar zxvf jdk-8u45-linux-x64.tar.gz -C /opt 
+
+RUN \
+  cd /tmp/openjdk9 && \
+  bash ./configure --with-cacerts-file=/etc/ssl/certs/java/cacerts --with-boot-jdk=/opt/jdk1.8.0_45
+
+RUN \  
+  cd /tmp/openjdk9 && \
+  make clean images
+
+RUN \  
+  cd /tmp/openjdk9 && \
+  cp -a build/linux-x86_64-normal-server-release/images/jdk \
+    /opt/openjdk9 
+
+RUN \  
+  cd /tmp/openjdk9 && \
+  find /opt/openjdk9 -type f -exec chmod a+r {} + && \
+  find /opt/openjdk9 -type d -exec chmod a+rx {} +
+
+ENV PATH /opt/openjdk9/bin:$PATH
+ENV JAVA_HOME /opt/openjdk9 

--- a/openjdk-docker/OpenJDK9/Dockerfile.valhalla
+++ b/openjdk-docker/OpenJDK9/Dockerfile.valhalla
@@ -1,4 +1,4 @@
-FROM base-image/openjdk:latest 
+FROM neomatrix369/openjdk-base-image:latest 
 
 MAINTAINER @adoptopenjdk
   


### PR DESCRIPTION
Hi Mani,

Having multiple Dockerfiles is cleaner and less confusing than another directory in my opinion.
I could not pass a -e variable into the build phase, so this is a quick and dirty for now.

Users should do a simple copy of Dockerfile.valhalla to Dockerfile and then run : 
./buildImageFromDockerfile.sh
./runImage.sh

regards,
Richard.
